### PR TITLE
feat!: Update project Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   lint:
     name: Lint files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -16,7 +16,7 @@ jobs:
       - run: npm run lint
   test:
     name: Test files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         version: [18, 20]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,14 @@ jobs:
   test:
     name: Test files
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        version: [18, 20]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version: ${{ matrix.version }}
           cache: npm
       - run: npm ci
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "jasmine": "^5.1.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.43",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jasmine"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "eslint": "^8.46.0",


### PR DESCRIPTION
Breaking change: minimum supported Node.js version is now 18.
