### PR TITLE
Add `--provenance` to `npm publish` command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
     uses: ./.github/workflows/ci.yml
   publish-to-npm:
     name: Publish to npm
+    permissions:
+      contents: read
+      id-token: write
     needs: ci
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +24,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish-to-github-packages:


### PR DESCRIPTION
See the following links on this new supply chain security feature that GitHub and npm offer.

- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements